### PR TITLE
locked_by size

### DIFF
--- a/lib/delayed/backend/data_mapper.rb
+++ b/lib/delayed/backend/data_mapper.rb
@@ -13,7 +13,7 @@ module Delayed
         property :handler,     Text, :lazy => false
         property :run_at,      Time, :index => :run_at_priority
         property :locked_at,   Time, :index => true
-        property :locked_by,   String
+        property :locked_by,   Text
         property :failed_at,   Time
         property :last_error,  Text
                 


### PR DESCRIPTION
Increase locked_by column size to fix issues with long hostnames crashing delayed_job worker. This has become a very common issue for our users of snorby (http://www.snorby.org).
