### PR TITLE
fix re-serialization of dm object

### DIFF
--- a/lib/delayed/serialization/data_mapper.rb
+++ b/lib/delayed/serialization/data_mapper.rb
@@ -2,7 +2,7 @@ DataMapper::Resource.class_eval do
   yaml_as "tag:ruby.yaml.org,2002:DataMapper"
 
   def self.yaml_new(klass, tag, val)
-    klass.find(val['id'])
+    klass.get!(val['id'])
   end
 
   def to_yaml_properties


### PR DESCRIPTION
Example:
NoMethodError:
       undefined method `deliver_without_delay' for #<Enumerator: Job:find("b04e206a-9a06-4d6e-9ac9-c8f2b21062de")>

Fixes re-serialization to use get! instead of find
