### PR TITLE
Update dj_dm to work with dj 3.0.4

### DIFF
--- a/lib/delayed/serialization/data_mapper.rb
+++ b/lib/delayed/serialization/data_mapper.rb
@@ -22,7 +22,7 @@ if YAML.parser.class.name =~ /syck/i
 else
   DataMapper::Resource.class_eval do
     def encode_with(coder)
-      coder["attributes"] = @attributes
+      coder["attributes"] = attributes.stringify_keys
       coder.tag = ['!ruby/DataMapper', self.class.name].join(':')
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,12 @@ class Story
   def tell; text; end
   def whatever(n, _); tell*n; end
   def self.count; end
-  def update_attributes(attributes); update(attributes); end
+  def update_attributes(attributes)
+    attributes.each do |k,v|
+      self[k] = v
+    end
+    self.save
+  end
 
   handle_asynchronously :whatever
 end


### PR DESCRIPTION
Changes:
- added == on id
- fixed cases where Time.now.utc.to_datetime + integer yielded days or months of time differences, instead of seconds
- refactored find_available and lock_exclusively!
- updated encode_with to use a stringified hash of attributes, which is not in the instance variable
- update_attributes on the test class, Story, is different from DM's #update

There is a change to delayed_job that is required for YAML deserialization to work. I'll link as soon as I make the PR.
